### PR TITLE
All my homies hate commonjs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-module.exports = function replaceAsync(string, searchValue, replacer) {
+export default function replaceAsync(string, searchValue, replacer) {
   try {
     if (typeof replacer === "function") {
       // 1. Run fake pass of `replace`, collect values from `replacer` calls
@@ -22,4 +22,4 @@ module.exports = function replaceAsync(string, searchValue, replacer) {
   } catch (error) {
     return Promise.reject(error);
   }
-};
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "string-replace-async",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Asynchronous String.prototype.replace()",
   "license": "MIT",
   "repository": "dsblv/string-replace-async",
@@ -9,8 +9,9 @@
     "email": "disobolev@icloud.com",
     "url": "https://github.com/dsblv"
   },
+  "type": "module",
   "engines": {
-    "node": ">=0.12"
+    "node": ">= 14.0.0"
   },
   "scripts": {
     "test": "jest"

--- a/readme.md
+++ b/readme.md
@@ -8,10 +8,16 @@
 $ npm install string-replace-async
 ```
 
+**Note:** If you're using pre-14 version of Node or your node codebase isn't converted to [ES Modules](https://nodejs.org/api/esm.html#esm_introduction) yet, please use Version 2 specifically!
+
+```
+$ npm install string-replace-async@^2.0.0
+```
+
 ## Usage
 
 ```js
-let replaceAsync = require("string-replace-async");
+import replaceAsync from "string-replace-async";
 
 await replaceAsync("#rebeccapurple", /#(\w+)/g, async (match, name) => {
   let color = await getColorByName(name);


### PR DESCRIPTION
I've decided it's a better move in terms of helping community to move forward. __Version 3 is dropping commonjs support!__

- Existing consumers aren't affected as it's a major version update
- Majority of bundlers support ESM seamlessly
- Node supports ESM since v14
- Commonjs projects are forced to stay on Version 2 _which we're going to support_ — a small price to pay for salvation